### PR TITLE
Support for other YAML modules

### DIFF
--- a/lib/XXX.pm
+++ b/lib/XXX.pm
@@ -17,7 +17,7 @@ sub import {
             $DumpModule = $args[$i];
             die "Don't know how to use XXX -with '$DumpModule'"
                 unless $DumpModule =~ /^(
-                                           YAML|
+                                           YAML(?:::.*)?|
                                            Data::Dumper|
                                            Data::Dump(?:::Color)?
                                        )$/x;


### PR DESCRIPTION
Regex was only allowing 'YAML'. It was stated that modules with names beginning with 'YAML' are supported so I've modified the regex accordingly.