### PR TITLE
Allow to specify a dump module as an environment variable

### DIFF
--- a/doc/XXX.swim
+++ b/doc/XXX.swim
@@ -70,6 +70,12 @@ By default, XXX uses YAML.pm to dump your data. You can change this like so:
   use XXX -with => 'JSON::Color';
   use XXX -with => 'JSON::SomeOtherJsonModule';
 
+You can also use the environment variable `PERL_XXX_DUMPER` to set
+the module, for example;
+
+  PERL_XXX_DUMPER=JSON::Color perl script.pl
+  PERL_XXX_DUMPER=YAML::PP::Highlight perl script.pl
+
 Only modules with names beginning with 'YAML' or 'JSON', and the Data::Dumper,
 Data::Dump, and Data::Dump::Color modules are supported.
 

--- a/lib/XXX.pm
+++ b/lib/XXX.pm
@@ -7,6 +7,10 @@ our @EXPORT = qw( WWW XXX YYY ZZZ );
 
 our $DumpModule = 'YAML';
 
+if ($ENV{PERL_XXX_DUMPER}) {
+    _set_dump_module($ENV{PERL_XXX_DUMPER});
+}
+
 sub import {
     my ($package, @args) = @_;
     for (my $i = 0; $i < @args; $i++) {
@@ -14,13 +18,7 @@ sub import {
         if ($arg eq '-with') {
             die "-with requires another argument"
               unless $i++ < @args;
-            $DumpModule = $args[$i];
-            die "Don't know how to use XXX -with '$DumpModule'"
-                unless $DumpModule =~ /^(
-                                           (?:YAML|JSON)(?:::.*)?|
-                                           Data::Dumper|
-                                           Data::Dump(?:::Color)?
-                                       )$/x;
+            _set_dump_module($args[ $i ]);
         }
         # TODO Deprecation. These options are now undocumented. Next releases:
         # warn, then die, then remove.
@@ -37,6 +35,17 @@ sub import {
     }
     @_ = ($package);
     goto &Exporter::import;
+}
+
+sub _set_dump_module {
+    my ($module) = @_;
+    $DumpModule = $module;
+    die "Don't know how to use XXX -with '$DumpModule'"
+        unless $DumpModule =~ /^(
+                                   (?:YAML|JSON)(?:::.*)?|
+                                   Data::Dumper|
+                                   Data::Dump(?:::Color)?
+                               )$/x;
 }
 
 sub _xxx_dump {

--- a/test/env.t
+++ b/test/env.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use v5.10;
+
+use Test::More;
+
+my $json_color = eval "use JSON::Color; 1";
+unless ($json_color) {
+    plan skip_all => "JSON::Color not installed";
+    exit;
+}
+
+plan tests => 1;
+
+my $data = { key => 'value' };
+
+$ENV{PERL_XXX_DUMPER} = 'JSON::Color';
+require XXX;
+
+my $json = JSON::Color::encode_json($data);
+eval { XXX::XXX($data) };
+my $error = $@;
+like ( $error, qr{\A\Q$json}, 'contains colored JSON' );


### PR DESCRIPTION
This allows to specify the dump module on commandline via an environment variable:
```
XXX_DUMP_MODULE=JSON::Color perl script.pl
XXX_DUMP_MODULE=YAML::PP::Highlight perl script.pl
```